### PR TITLE
Add missing sqlite libs for PHP compilation

### DIFF
--- a/build/install-deps.sh
+++ b/build/install-deps.sh
@@ -18,7 +18,7 @@ if [ "$OS" == "Ubuntu" ]; then
 	sudo apt-get update
 	sudo apt-get -y upgrade
 	if [[ "$VERSION" == "10.04"* ]]; then
-		sudo apt-get -y install build-essential autoconf automake libssl-dev libsnmp-dev mercurial libbz2-dev libldap2-dev libpcre3-dev libxml2-dev libpq-dev libzip-dev libcurl4-openssl-dev libgdbm-dev libmysqlclient-dev libgmp3-dev libjpeg-dev libpng12-dev libc-client2007e-dev libsasl2-dev libmcrypt-dev libaspell-dev libpspell-dev libexpat1-dev imagemagick libmagickwand-dev libmagickcore-dev unzip libicu-dev
+		sudo apt-get -y install build-essential autoconf automake libssl-dev libsnmp-dev mercurial libbz2-dev libldap2-dev libpcre3-dev libxml2-dev libpq-dev libzip-dev libcurl4-openssl-dev libgdbm-dev libmysqlclient-dev libgmp3-dev libjpeg-dev libpng12-dev libc-client2007e-dev libsasl2-dev libmcrypt-dev libaspell-dev libpspell-dev libexpat1-dev imagemagick libmagickwand-dev libmagickcore-dev unzip libicu-dev libsqlite3-dev
 	else
 		echo "Version [$VERSION] of [$OS] is not supported by this version of the script."
         echo "Check out the appropriate build branch for your version."


### PR DESCRIPTION
sqlite libraries are missing on the box-cutter boxes. This causes PHP compilation to fail.
