### PR TITLE
Update trusty, lucid, precise ubuntu image locations

### DIFF
--- a/vagrant/lucid/Vagrantfile
+++ b/vagrant/lucid/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 #######################################################################################
 ######################### UBUNTU 10.04 LUCID ##########################################
-  config.vm.box = "box-cutter/ubuntu1004"
+  config.vm.box = "boxcutter/ubuntu1004"
   config.vm.synced_folder '../../', '/vagrant'
 
   config.vm.define "lucid" do |lucid|

--- a/vagrant/precise/Vagrantfile
+++ b/vagrant/precise/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 #######################################################################################
 ######################### UBUNTU 12.04 precise ########################################
-  config.vm.box = "box-cutter/ubuntu1204"
+  config.vm.box = "boxcutter/ubuntu1204"
   config.vm.synced_folder '../../', '/vagrant'
 
   config.vm.define "precise" do |precise|

--- a/vagrant/trusty/Vagrantfile
+++ b/vagrant/trusty/Vagrantfile
@@ -8,7 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
 #######################################################################################
 ######################### UBUNTU 14.04 trusty #########################################
-  config.vm.box = "box-cutter/ubuntu1404"
+  config.vm.box = "boxcutter/ubuntu1404"
   config.vm.synced_folder '../../', '/vagrant'
 
   config.vm.define "trusty" do |trusty|


### PR DESCRIPTION
Somewhere along the line the image names got renamed and the script fails when trying to retrieve them. This changes the image references to their new names.

For example: https://atlas.hashicorp.com/boxcutter/boxes/ubuntu1404
